### PR TITLE
feat(dhcp): populate BOOTP file header field in PXE proxy response

### DIFF
--- a/internal/server/dhcp/proxy.go
+++ b/internal/server/dhcp/proxy.go
@@ -239,22 +239,28 @@ func offerDHCP(req *dhcpv4.DHCPv4, apiAdvertiseAddress string, apiPort int, fwty
 		resp.UpdateOption(dhcpv4.OptClassIdentifier("PXEClient"))
 	}
 
+	// For TFTP firmware types, the boot filename is also written to the BOOTP `file` header field
+	// in addition to DHCP option 67. U-Boot's ProxyDHCP code path reads the filename from the header
+	// directly and never processes DHCP options, so without this the BOOTP file field would be empty.
 	switch fwtype {
 	case FirmwareX86PC:
 		// This is completely standard PXE: just load a file from TFTP.
 		resp.UpdateOption(dhcpv4.OptTFTPServerName(serverIP.String()))
-		resp.UpdateOption(dhcpv4.OptBootFileName("undionly.kpxe"))
+		resp.BootFileName = "undionly.kpxe"
+		resp.UpdateOption(dhcpv4.OptBootFileName(resp.BootFileName))
 	case FirmwareX86Ipxe:
 		// Almost standard PXE, but the boot filename needs to be a URL.
 		resp.UpdateOption(dhcpv4.OptBootFileName(fmt.Sprintf("tftp://%s/undionly.kpxe", serverIP)))
 	case FirmwareX86EFI:
 		// This is completely standard PXE: just load a file from TFTP.
 		resp.UpdateOption(dhcpv4.OptTFTPServerName(serverIP.String()))
-		resp.UpdateOption(dhcpv4.OptBootFileName("snp.efi"))
+		resp.BootFileName = "snp.efi"
+		resp.UpdateOption(dhcpv4.OptBootFileName(resp.BootFileName))
 	case FirmwareARMEFI:
 		// This is completely standard PXE: just load a file from TFTP.
 		resp.UpdateOption(dhcpv4.OptTFTPServerName(serverIP.String()))
-		resp.UpdateOption(dhcpv4.OptBootFileName("snp-arm64.efi"))
+		resp.BootFileName = "snp-arm64.efi"
+		resp.UpdateOption(dhcpv4.OptBootFileName(resp.BootFileName))
 	case FirmwareX86HTTP:
 		// This is completely standard HTTP-boot: just load a file from HTTP.
 		resp.UpdateOption(dhcpv4.OptBootFileName(fmt.Sprintf("http://%s/tftp/amd64/snp.efi", ipPort)))


### PR DESCRIPTION
For TFTP-based PXE firmware types (X86PC, X86EFI, ARMEFI), also set the BOOTP BootFileName (file) header field in addition to option 67.

Some legacy BIOS PXE ROMs predate DHCP option 67 and read the BOOTP file header field directly. UEFI PXE clients may also ignore option 67 - like U-Boot which only has basic support for ProxyDHCP.

Fixes #11