### PR TITLE
test: bind the advertised PXE boot files to the served files

### DIFF
--- a/internal/server/constants/constants.go
+++ b/internal/server/constants/constants.go
@@ -8,4 +8,7 @@ package constants
 const (
 	// IPXEURLPath is the path from which the HTTP server serves the iPXE scripts.
 	IPXEURLPath = "ipxe"
+
+	// ConfigURLPath is the path from which the HTTP server serves the machine configs.
+	ConfigURLPath = "config"
 )

--- a/internal/server/dhcp/proxy.go
+++ b/internal/server/dhcp/proxy.go
@@ -172,7 +172,7 @@ func (p *Proxy) handlePacket(port int) func(conn net.PacketConn, peer net.Addr, 
 			return
 		}
 
-		resp, err := offerDHCP(m, p.apiAdvertiseAddress, p.apiPort, fwtype, port)
+		resp, err := OfferDHCP(m, p.apiAdvertiseAddress, p.apiPort, fwtype, port)
 		if err != nil {
 			logger.Error("failed to construct ProxyDHCP response", zap.Error(err))
 
@@ -270,11 +270,11 @@ func validateDHCP(m *dhcpv4.DHCPv4) (fwtype Firmware, err error) {
 	return fwtype, nil
 }
 
-// offerDHCP constructs the DHCP response for a PXE boot request.
+// OfferDHCP constructs the DHCP response for a PXE boot request.
 //
 // On port 67, this is a DHCPOFFER in response to DHCPDISCOVER.
 // On port 4011, this is a DHCPACK in response to DHCPREQUEST.
-func offerDHCP(req *dhcpv4.DHCPv4, apiAdvertiseAddress string, apiPort int, fwtype Firmware, port int) (*dhcpv4.DHCPv4, error) {
+func OfferDHCP(req *dhcpv4.DHCPv4, apiAdvertiseAddress string, apiPort int, fwtype Firmware, port int) (*dhcpv4.DHCPv4, error) {
 	serverIP := net.ParseIP(apiAdvertiseAddress)
 	if serverIP == nil {
 		return nil, fmt.Errorf("invalid API advertise address %q: not a valid IP", apiAdvertiseAddress)

--- a/internal/server/ipxe/boot_contract_test.go
+++ b/internal/server/ipxe/boot_contract_test.go
@@ -1,0 +1,98 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package ipxe_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/siderolabs/booter/internal/server/dhcp"
+	"github.com/siderolabs/booter/internal/server/ipxe"
+	"github.com/siderolabs/booter/internal/server/server"
+)
+
+// TestAdvertisedBootFilesAreServed binds the two halves of the PXE boot contract: every boot file
+// name and URL the DHCP proxy hands out must resolve against the patched files booter actually
+// serves. The names appear on both sides as independent literals, so this is the test that fails
+// when either side drifts.
+func TestAdvertisedBootFilesAreServed(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	script := []byte("#!ipxe\nchain http://example.org/boot")
+
+	files, err := ipxe.PatchBinaries(script)
+	require.NoError(t, err)
+
+	notFound := http.NotFoundHandler()
+	handler := server.NewMuxHandler(notFound, notFound, files, logger)
+
+	offer := func(t *testing.T, fwtype dhcp.Firmware) *dhcpv4.DHCPv4 {
+		t.Helper()
+
+		req, err := dhcpv4.New(
+			dhcpv4.WithMessageType(dhcpv4.MessageTypeRequest),
+			dhcpv4.WithHwAddr([]byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}),
+		)
+		require.NoError(t, err)
+
+		resp, err := dhcp.OfferDHCP(req, "192.168.1.100", 8081, fwtype, dhcp.Port4011)
+		require.NoError(t, err)
+
+		return resp
+	}
+
+	t.Run("HTTP boot URLs resolve to patched binaries", func(t *testing.T) {
+		for _, fwtype := range []dhcp.Firmware{dhcp.FirmwareX86HTTP, dhcp.FirmwareARMHTTP} {
+			bootURL, err := url.Parse(offer(t, fwtype).BootFileNameOption())
+			require.NoError(t, err)
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, bootURL.Path, nil))
+
+			require.Equal(t, http.StatusOK, rec.Code, "the advertised URL path %q is not served", bootURL.Path)
+			assert.True(t, bytes.Contains(rec.Body.Bytes(), script), "the file served at %q does not contain the patched script", bootURL.Path)
+		}
+	})
+
+	t.Run("TFTP boot file names are served", func(t *testing.T) {
+		// The TFTP server serves the same files map.
+		for _, tt := range []struct {
+			fwtype       dhcp.Firmware
+			checkPatched bool // the BIOS binary is compressed, so the script is not in it verbatim
+		}{
+			{fwtype: dhcp.FirmwareX86PC},
+			{fwtype: dhcp.FirmwareX86EFI, checkPatched: true},
+			{fwtype: dhcp.FirmwareARMEFI, checkPatched: true},
+		} {
+			name := offer(t, tt.fwtype).BootFileName
+
+			contents, ok := files[name]
+			require.True(t, ok, "the advertised TFTP boot file %q is not among the served files", name)
+			require.NotEmpty(t, contents)
+
+			if tt.checkPatched {
+				assert.True(t, bytes.Contains(contents, script), "the advertised TFTP boot file %q does not contain the patched script", name)
+			}
+		}
+	})
+
+	t.Run("iPXE chain URL file is served", func(t *testing.T) {
+		bootURL, err := url.Parse(offer(t, dhcp.FirmwareX86Ipxe).BootFileNameOption())
+		require.NoError(t, err)
+
+		name := strings.TrimPrefix(bootURL.Path, "/")
+
+		_, ok := files[name]
+		require.True(t, ok, "the advertised iPXE chain file %q is not among the served files", name)
+	})
+}

--- a/internal/server/ipxe/handler.go
+++ b/internal/server/ipxe/handler.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"go.uber.org/zap"
+
+	booterconstants "github.com/siderolabs/booter/internal/server/constants"
 )
 
 const (
@@ -161,7 +163,7 @@ func (handler *Handler) consoleKernelArgs(arch string) []string {
 // NewHandler creates a new iPXE server.
 func NewHandler(configServerEnabled bool, imageFactoryClient ImageFactoryClient, options HandlerOptions, logger *zap.Logger) (*Handler, error) {
 	apiHostPort := net.JoinHostPort(options.APIAdvertiseAddress, strconv.Itoa(options.APIPort))
-	talosConfigURL := fmt.Sprintf("http://%s/config?u=${uuid}", apiHostPort)
+	talosConfigURL := fmt.Sprintf("http://%s/%s?u=${uuid}", apiHostPort, booterconstants.ConfigURLPath)
 	talosConfigKernelArg := fmt.Sprintf("%s=%s", constants.KernelParamConfig, talosConfigURL)
 
 	if options.SchematicID != "" {

--- a/internal/server/server/server.go
+++ b/internal/server/server/server.go
@@ -33,7 +33,7 @@ type Server struct {
 func New(ctx context.Context, listenAddress string, port int, configHandler, ipxeHandler http.Handler, files map[string][]byte, logger *zap.Logger) *Server {
 	httpServer := &http.Server{
 		Addr:    net.JoinHostPort(listenAddress, strconv.Itoa(port)),
-		Handler: newMuxHandler(configHandler, ipxeHandler, files, logger),
+		Handler: NewMuxHandler(configHandler, ipxeHandler, files, logger),
 		BaseContext: func(net.Listener) context.Context {
 			return ctx
 		},
@@ -79,11 +79,13 @@ func (s *Server) shutdownOnCancel(ctx context.Context, server *http.Server) erro
 	return nil
 }
 
-func newMuxHandler(configHandler, ipxeHandler http.Handler, files map[string][]byte, logger *zap.Logger) http.Handler {
+// NewMuxHandler creates the HTTP handler that multiplexes the config, the iPXE scripts, and the
+// boot file serving.
+func NewMuxHandler(configHandler, ipxeHandler http.Handler, files map[string][]byte, logger *zap.Logger) http.Handler {
 	mux := http.NewServeMux()
 
 	if configHandler != nil {
-		mux.Handle("/config", configHandler)
+		mux.Handle("/"+constants.ConfigURLPath, configHandler)
 	}
 
 	mux.Handle(fmt.Sprintf("/%s/{script}", constants.IPXEURLPath), ipxeHandler)


### PR DESCRIPTION
The DHCP proxy advertises boot file names and HTTP boot URLs, and the TFTP and HTTP servers serve the patched iPXE binaries under names that must match. Each side previously hardcoded its half of the contract, so a drift on either side would keep the build green while breaking boots, which has happened before: the HTTP boot URLs of the sibling bare-metal provider pointed at paths nothing served for several releases. A new test resolves every boot file name and URL the proxy actually hands out against the files that are actually served, and fails when either side drifts. The DHCP response builder and the HTTP handler constructor are exported for it.

The machine config URL had the same latent mismatch shape, built from a literal that had to match another literal in the HTTP route setup. Both sides now come from a shared constant, so they cannot drift.